### PR TITLE
Fixes: #3

### DIFF
--- a/tabu.sty
+++ b/tabu.sty
@@ -114,6 +114,10 @@
 \def\tabu@everyrowfalse{\global\let\iftabu@everyrow \iffalse}
 \newif \iftabu@long
 \newif \iftabuscantokens
+%% TABU-FIXED (issue #3)
+%% REMOVED \tabu@verbatim
+%% \def\tabu@rescan {\tabu@verbatim \scantokens  }
+\let\tabu@rescan \scantokens
 %% Utilities (for internal usage) -----------------------------------
 \def\tabu@gobblespace #1  {#1}
 \def\tabu@gobbletoken #1#2{#1}
@@ -958,7 +962,7 @@
     \NC@list{\NC@do \tabu@rewritemulticolumn}%
     \expandafter\@gobbletwo % gobbles \multispan{#1}
          \tabu@multicolumnORI{#1}{\tabu@rewritemulticolumn #2}%
-                {\iftabuscantokens \scantokens \else \expandafter\@firstofone \fi
+                {\iftabuscantokens \tabu@rescan \else \expandafter\@firstofone \fi
                 {#3}}%
 }% \tabu@multic@lumn
 %% The X column(s): rewriting process -----------------------------
@@ -1249,6 +1253,8 @@
     \ifnum \count@>\thr@@ \let\@halignto \@empty  \tabucolX@init
                           \def\tabu@lasttry{\m@ne\p@}\fi
     \begingroup \iffalse{\fi \ifnum0=`}\fi
+%% TABU-FIXED (issue #3)
+%% tabu* now collects body with a catcode 12 backslash
         \toks@{}\def\tabu@stack{b}\iftabuscantokens
                                     \endlinechar=10 \catcode`\\=12 \obeyspaces
                                     \expandafter\@firstoftwo
@@ -1278,6 +1284,8 @@
     \fi
 }% \tabu@Xinit
 %% Collecting the environment body ----------------------------------
+%% TABU-FIXED (issue #3)
+%% this macro now only for non-scantokens type of body collecting
 \long\def\tabu@collectbody #1#2\end #3{%
     \edef\tabu@stack{\tabu@pushbegins #2\begin\end\expandafter\@gobble\tabu@stack}%
     \ifx \tabu@stack\@empty
@@ -1298,6 +1306,8 @@
 \def\tabu@endofcollect #1{\ifnum0=`{}\fi
                           \expandafter\endgroup \the\toks@  #1%
 }% \tabu@endofcollect
+%% TABU-FIXED (issue #3)
+%% collects body with a catcode 12 backslash for later scantokenization
 \catcode`\| \z@
 \catcode`\\ 12
 |long|def|tabu@collectbody@forscan #1#2#3\end{%
@@ -1387,7 +1397,7 @@
 \def\tabu@shorttrial {\setbox\tabu@box \hbox\bgroup \tabu@seteverycr
     \ifx \tabu@savecounters\relax \else
                 \let\tabu@savecounters \relax \tabu@clckpt \fi
-    $\iftabuscantokens \scantokens \else \expandafter\@secondoftwo \fi
+    $\iftabuscantokens \tabu@rescan \else \expandafter\@secondoftwo \fi
        \expandafter{\expandafter \tabuthepreamble
                          \the\tabu@thebody
                          \csname tabu@adl@endtrial\endcsname
@@ -1396,7 +1406,7 @@
 \def\tabu@longtrial {\setbox\tabu@box \hbox\bgroup \tabu@seteverycr
     \ifx \tabu@savecounters\relax \else
                 \let\tabu@savecounters \relax \tabu@clckpt \fi
-    \iftabuscantokens \scantokens \else \expandafter\@secondoftwo \fi
+    \iftabuscantokens \tabu@rescan \else \expandafter\@secondoftwo \fi
        \expandafter{\expandafter \tabuthepreamble
                          \the\tabu@thebody
                          \tabuendlongtrial}\egroup      % got \tabu@box
@@ -1419,7 +1429,7 @@
     \else               \expandafter\@secondoftwo
     \fi
         {\expandafter \tabu@closetrialsgroup \expandafter
-         \scantokens \expandafter{%
+         \tabu@rescan \expandafter{%
                     \expandafter\tabuthepreamble
                         \the\expandafter\tabu@thebody
                                     \iftabu@long \else \endarray \fi}}
@@ -2090,6 +2100,9 @@
     \fi\fi
 }% \tabu@printdecimal
 %% Verbatim inside X columns ----------------------------------------
+%% TABU-FIXED (issue #3)
+%% REMOVED \tabu@verbatim, \tabu@verb, \tabu@FV@DefineCheckEnd, ...
+%% REMOVED \tabu@fancyvrb, \tabu@FV@CheckEnd, etc...
 \def\tabu@FV@ListProcessLine #1{%
   \hbox {%to \hsize{%
     \kern\leftmargin
@@ -2562,6 +2575,10 @@
             ifHy@hyperfootnotes\else iffalse\fi\endcsname
         \let\tabu@footnotetext \tabu@Hy@ftntext
         \let\tabu@xfootnote    \tabu@Hy@xfootnote \fi
+%% TABU-FIXED (issue #3)
+%% REMOVED \tabu@fancyvrb
+%%  \ifdefined\FV@DefineCheckEnd% <fancyvrb>
+%%          \tabu@fancyvrb  \fi
     \ifdefined\color            % <color / xcolor>
         \let\tabu@color \color
         \def\tabu@leavevmodecolor ##1{%

--- a/tabu.sty
+++ b/tabu.sty
@@ -1250,8 +1250,14 @@
     \ifnum \count@>\thr@@ \let\@halignto \@empty  \tabucolX@init
                           \def\tabu@lasttry{\m@ne\p@}\fi
     \begingroup \iffalse{\fi \ifnum0=`}\fi
-        \toks@{}\def\tabu@stack{b}\iftabuscantokens \endlinechar=10 \obeyspaces \fi %
-                                  \tabu@collectbody \tabu@strategy %
+        \toks@{}\def\tabu@stack{b}\iftabuscantokens
+                                    \endlinechar=10 \catcode`\\=12 \obeyspaces
+                                    \expandafter\@firstoftwo
+                                  \else
+                                    \expandafter\@secondoftwo
+                                  \fi %
+                                  {\tabu@collectbody@forscan\tabu@strategy{}}%
+                                  {\tabu@collectbody\tabu@strategy}%
 }% \tabu@setstrategy
 \def\tabu@savecounters{%
     \def\@elt ##1{\csname c@##1\endcsname\the\csname c@##1\endcsname}%
@@ -1278,12 +1284,7 @@
     \ifx \tabu@stack\@empty
         \toks@\expandafter{\expandafter\tabu@thebody\expandafter{\the\toks@ #2}%
                 \def\tabu@end@envir{\end{#3}}%
-                \iftabuscantokens
-                    \iftabu@long \def\tabu@endenvir {\end{#3}\tabu@gobbleX}%
-                    \else        \def\tabu@endenvir {\let\endarray \@empty
-                                                     \end{#3}\tabu@gobbleX}%
-                    \fi
-                \else           \def\tabu@endenvir  {\end{#3}}\fi}%
+                \def\tabu@endenvir {\end{#3}}}%
         \let\tabu@collectbody \tabu@endofcollect
     \else\def\tabu@temp{#3}%
         \ifx \tabu@temp\@empty \toks@\expandafter{\the\toks@ #2\end }%
@@ -1298,6 +1299,58 @@
 \def\tabu@endofcollect #1{\ifnum0=`{}\fi
                           \expandafter\endgroup \the\toks@  #1%
 }% \tabu@endofcollect
+\catcode`\| \z@
+\catcode`\\ 12
+|long|def|tabu@collectbody@forscan #1#2#3\end{%
+    |def|tabu@collectbody@forscan@next{|tabu@collectbody@forscan{#1}}%
+    |def|tabu@collectbody@forscan@partial{#2#3}%
+    |futurelet|tabu@temp@token|tabu@collectbody@forscan@a
+}%
+|def|tabu@collectbody@forscan@a{%
+    |ifcat|tabu@temp@token e%
+        |expandafter|@firstoftwo
+    |else
+        |expandafter|@secondoftwo
+    |fi
+    |tabu@collectbody@forscan@aa
+    |tabu@collectbody@forscan@b
+}%
+|def|tabu@collectbody@forscan@aa #1{%
+    |expandafter|tabu@collectbody@forscan@next|expandafter{|tabu@collectbody@forscan@partial\end#1}%
+}%
+|def|tabu@collectbody@forscan@b #1{%
+    |edef|tabu@stack{|expandafter|tabu@pushbegins@forscan
+                     |tabu@collectbody@forscan@partial\begin|relax|expandafter|@gobble|tabu@stack}%
+    |ifx |tabu@stack|@empty
+        |expandafter|@firstoftwo
+    |else
+        |expandafter|@secondoftwo
+    |fi
+    {|expandafter|tabu@collectbody@forscan@end|expandafter{|tabu@collectbody@forscan@partial}{#1}}%
+    {|expandafter|tabu@collectbody@forscan@continue|expandafter{|tabu@collectbody@forscan@partial}{#1}}%
+}%
+|def|tabu@collectbody@forscan@end #1#2{%
+    |toks@|expandafter{|expandafter|tabu@thebody|expandafter{|the|toks@ #1}%
+            |def|tabu@end@envir{|end{#2}}%
+            |iftabu@long |def|tabu@endenvir {|end{#2}|tabu@gobbleX}%
+            |else        |def|tabu@endenvir {|let|endarray |@empty
+                                             |end{#2}|tabu@gobbleX}%
+            |fi}%
+    |let|tabu@collectbody@forscan|tabu@endofcollect
+    |tabu@collectbody@forscan@next
+}%
+|def|tabu@collectbody@forscan@continue #1#2{%
+    |def|tabu@temp{#2}%
+    |ifx |tabu@temp|@empty |toks@|expandafter{|the|toks@ #1\end }%
+    |else |ifx|tabu@temp|tabu@@spxiii |toks@|expandafter{|the|toks@ #1\end#2}%
+    |else |ifx|tabu@temp|tabu@X |toks@|expandafter{|the|toks@ #1\end#2}%
+    |else |toks@|expandafter{|the|toks@ #1\end{#2}}%
+    |fi|fi|fi
+    |tabu@collectbody@forscan@next{}%
+}% \tabu@collectbody@forscan
+|long|def|tabu@pushbegins@forscan #1\begin#2{|ifx|relax#2|else b|expandafter|tabu@pushbegins@forscan|fi}%
+|catcode`|\ |z@
+\catcode`\| 12
 %% The trials: switching between strategies -------------------------
 \def\tabu@strategy {\relax  % stops \count@ assignment !
     \ifcase\count@          % case 0 = print with vertical adjustment (outer is finished)
@@ -2041,8 +2094,8 @@
 }% \tabu@printdecimal
 %% Verbatim inside X columns ----------------------------------------
 \def\tabu@verbatim{%
-    \let\verb \tabu@verb
-    \let\FV@DefineCheckEnd \tabu@FV@DefineCheckEnd
+    % \let\verb \tabu@verb
+    % \let\FV@DefineCheckEnd \tabu@FV@DefineCheckEnd
 }% \tabu@verbatim
 \let\tabu@ltx@verb \verb
 \def\tabu@verb{\@ifstar {\tabu@ltx@verb*} \tabu@ltx@verb}

--- a/tabu.sty
+++ b/tabu.sty
@@ -2090,34 +2090,6 @@
     \fi\fi
 }% \tabu@printdecimal
 %% Verbatim inside X columns ----------------------------------------
-\def\tabu@verbatim{%
-    % \let\verb \tabu@verb
-    % \let\FV@DefineCheckEnd \tabu@FV@DefineCheckEnd
-}% \tabu@verbatim
-\let\tabu@ltx@verb \verb
-\def\tabu@verb{\@ifstar {\tabu@ltx@verb*} \tabu@ltx@verb}
-\def\tabu@fancyvrb {%
-    \def\tabu@FV@DefineCheckEnd ##1{%
-        \def\tabu@FV@DefineCheckEnd{%
-            ##1% <original definition (if fancyvrb is loaded)>
-            \let\FV@CheckEnd     \tabu@FV@CheckEnd
-            \let\FV@@CheckEnd    \tabu@FV@@CheckEnd
-            \let\FV@@@CheckEnd   \tabu@FV@@@CheckEnd
-            \edef\FV@EndScanning{%
-            \def\noexpand\next{\noexpand\end{\FV@EnvironName}}%
-                \global\let\noexpand\FV@EnvironName\relax
-                \noexpand\next}%
-            \xdef\FV@EnvironName{\detokenize\expandafter{\FV@EnvironName}}}%
-    }\expandafter\tabu@FV@DefineCheckEnd\expandafter{\FV@DefineCheckEnd}
-}% \tabu@fancyvrb
-\def\tabu@FV@CheckEnd  #1{\expandafter\FV@@CheckEnd \detokenize{#1\end{}}\@nil}
-\edef\tabu@FV@@@CheckEnd {\detokenize{\end{}}}
-\begingroup
-\catcode`\[1      \catcode`\]2
-\@makeother\{     \@makeother\}
-   \edef\x[\endgroup
-      \def\noexpand\tabu@FV@@CheckEnd ##1\detokenize[\end{]##2\detokenize[}]##3%
-   ]\x               \@nil{\def\@tempa{#2}\def\@tempb{#3}}
 \def\tabu@FV@ListProcessLine #1{%
   \hbox {%to \hsize{%
     \kern\leftmargin
@@ -2590,8 +2562,6 @@
             ifHy@hyperfootnotes\else iffalse\fi\endcsname
         \let\tabu@footnotetext \tabu@Hy@ftntext
         \let\tabu@xfootnote    \tabu@Hy@xfootnote \fi
-    \ifdefined\FV@DefineCheckEnd% <fancyvrb>
-            \tabu@fancyvrb  \fi
     \ifdefined\color            % <color / xcolor>
         \let\tabu@color \color
         \def\tabu@leavevmodecolor ##1{%

--- a/tabu.sty
+++ b/tabu.sty
@@ -1348,7 +1348,7 @@
 }% \tabu@collectbody@forscan@end
 |def|tabu@collectbody@forscan@continue #1#2{%
     |def|tabu@temp{#2}%
-    |ifx |tabu@temp|@empty |toks@|expandafter{|the|toks@ #1\end }%
+    |ifx |tabu@temp|@empty |toks@|expandafter{|the|toks@ #1\end}%
     |else |ifx|tabu@temp|tabu@@spxiii |toks@|expandafter{|the|toks@ #1\end#2}%
     |else |ifx|tabu@temp|tabu@X |toks@|expandafter{|the|toks@ #1\end#2}%
     |else |toks@|expandafter{|the|toks@ #1\end{#2}}%

--- a/tabu.sty
+++ b/tabu.sty
@@ -1291,7 +1291,12 @@
     \ifx \tabu@stack\@empty
         \toks@\expandafter{\expandafter\tabu@thebody\expandafter{\the\toks@ #2}%
                 \def\tabu@end@envir{\end{#3}}%
-                \def\tabu@endenvir {\end{#3}}}%
+                \iftabuscantokens
+                    \iftabu@long \def\tabu@endenvir {\end{#3}\tabu@gobbleX}%
+                    \else        \def\tabu@endenvir {\let\endarray \@empty
+                                                     \end{#3}\tabu@gobbleX}%
+                    \fi
+                \else           \def\tabu@endenvir  {\end{#3}}\fi}%
         \let\tabu@collectbody \tabu@endofcollect
     \else\def\tabu@temp{#3}%
         \ifx \tabu@temp\@empty \toks@\expandafter{\the\toks@ #2\end }%

--- a/tabu.sty
+++ b/tabu.sty
@@ -1329,29 +1329,32 @@
     |edef|tabu@stack{|expandafter|tabu@pushbegins@forscan
                      |tabu@collectbody@forscan@partial\begin|relax|expandafter|@gobble|tabu@stack}%
     |ifx |tabu@stack|@empty
-        |expandafter|@firstoftwo
+        |expandafter|tabu@collectbody@forscan@end
     |else
-        |expandafter|@secondoftwo
+        |expandafter|tabu@collectbody@forscan@continue
     |fi
-    {|expandafter|tabu@collectbody@forscan@end|expandafter{|tabu@collectbody@forscan@partial}{#1}}%
-    {|expandafter|tabu@collectbody@forscan@continue|expandafter{|tabu@collectbody@forscan@partial}{#1}}%
+    {#1}%
 }% \tabu@collectbody@forscan@b
-|def|tabu@collectbody@forscan@end #1#2{%
-    |toks@|expandafter{|expandafter|tabu@thebody|expandafter{|the|toks@ #1}%
-            |def|tabu@end@envir{|end{#2}}%
-            |iftabu@long |def|tabu@endenvir {|end{#2}|tabu@gobbleX}%
+|def|tabu@collectbody@forscan@end #1{%
+    |edef|tabu@@temp{|tabu@thebody{|the|toks@
+                                   |unexpanded|expandafter{|tabu@collectbody@forscan@partial}}%
+                    }%
+    |toks@|expandafter{|tabu@@temp
+            |def|tabu@end@envir{|end{#1}}%
+            |iftabu@long |def|tabu@endenvir {|end{#1}|tabu@gobbleX}%
             |else        |def|tabu@endenvir {|let|endarray |@empty
-                                             |end{#2}|tabu@gobbleX}%
+                                             |end{#1}|tabu@gobbleX}%
             |fi}%
     |let|tabu@collectbody@forscan|tabu@endofcollect
     |tabu@collectbody@forscan@next
 }% \tabu@collectbody@forscan@end
-|def|tabu@collectbody@forscan@continue #1#2{%
-    |def|tabu@temp{#2}%
-    |ifx |tabu@temp|@empty |toks@|expandafter{|the|toks@ #1\end}%
-    |else |ifx|tabu@temp|tabu@@spxiii |toks@|expandafter{|the|toks@ #1\end#2}%
-    |else |ifx|tabu@temp|tabu@X |toks@|expandafter{|the|toks@ #1\end#2}%
-    |else |toks@|expandafter{|the|toks@ #1\end{#2}}%
+|def|tabu@collectbody@forscan@continue #1{%
+    |edef|tabu@@temp{|the|toks@|unexpanded|expandafter{|tabu@collectbody@forscan@partial\end}}%
+    |def|tabu@temp{#1}%
+    |ifx |tabu@temp|@empty |toks@|expandafter{|tabu@@temp}%
+    |else |ifx|tabu@temp|tabu@@spxiii |toks@|expandafter{|tabu@@temp#1}%
+    |else |ifx|tabu@temp|tabu@X |toks@|expandafter{|tabu@@temp#1}%
+    |else |toks@|expandafter{|tabu@@temp{#1}}%
     |fi|fi|fi
     |tabu@collectbody@forscan@next{}%
 }% \tabu@collectbody@forscan@continue

--- a/tabu.sty
+++ b/tabu.sty
@@ -114,7 +114,6 @@
 \def\tabu@everyrowfalse{\global\let\iftabu@everyrow \iffalse}
 \newif \iftabu@long
 \newif \iftabuscantokens
-\def\tabu@rescan {\tabu@verbatim \scantokens  }
 %% Utilities (for internal usage) -----------------------------------
 \def\tabu@gobblespace #1  {#1}
 \def\tabu@gobbletoken #1#2{#1}
@@ -959,7 +958,7 @@
     \NC@list{\NC@do \tabu@rewritemulticolumn}%
     \expandafter\@gobbletwo % gobbles \multispan{#1}
          \tabu@multicolumnORI{#1}{\tabu@rewritemulticolumn #2}%
-                {\iftabuscantokens \tabu@rescan \else \expandafter\@firstofone \fi
+                {\iftabuscantokens \scantokens \else \expandafter\@firstofone \fi
                 {#3}}%
 }% \tabu@multic@lumn
 %% The X column(s): rewriting process -----------------------------
@@ -1305,19 +1304,17 @@
     |def|tabu@collectbody@forscan@next{|tabu@collectbody@forscan{#1}}%
     |def|tabu@collectbody@forscan@partial{#2#3}%
     |futurelet|tabu@temp@token|tabu@collectbody@forscan@a
-}%
+}% \tabu@collectbody@forscan
 |def|tabu@collectbody@forscan@a{%
-    |ifcat|tabu@temp@token e%
-        |expandafter|@firstoftwo
+    |ifcat|noexpand|tabu@temp@token e%
+        |expandafter|tabu@collectbody@forscan@aa
     |else
-        |expandafter|@secondoftwo
+        |expandafter|tabu@collectbody@forscan@b
     |fi
-    |tabu@collectbody@forscan@aa
-    |tabu@collectbody@forscan@b
-}%
+}% \tabu@collectbody@forscan@a
 |def|tabu@collectbody@forscan@aa #1{%
     |expandafter|tabu@collectbody@forscan@next|expandafter{|tabu@collectbody@forscan@partial\end#1}%
-}%
+}% \tabu@collectbody@forscan@aa
 |def|tabu@collectbody@forscan@b #1{%
     |edef|tabu@stack{|expandafter|tabu@pushbegins@forscan
                      |tabu@collectbody@forscan@partial\begin|relax|expandafter|@gobble|tabu@stack}%
@@ -1328,7 +1325,7 @@
     |fi
     {|expandafter|tabu@collectbody@forscan@end|expandafter{|tabu@collectbody@forscan@partial}{#1}}%
     {|expandafter|tabu@collectbody@forscan@continue|expandafter{|tabu@collectbody@forscan@partial}{#1}}%
-}%
+}% \tabu@collectbody@forscan@b
 |def|tabu@collectbody@forscan@end #1#2{%
     |toks@|expandafter{|expandafter|tabu@thebody|expandafter{|the|toks@ #1}%
             |def|tabu@end@envir{|end{#2}}%
@@ -1338,7 +1335,7 @@
             |fi}%
     |let|tabu@collectbody@forscan|tabu@endofcollect
     |tabu@collectbody@forscan@next
-}%
+}% \tabu@collectbody@forscan@end
 |def|tabu@collectbody@forscan@continue #1#2{%
     |def|tabu@temp{#2}%
     |ifx |tabu@temp|@empty |toks@|expandafter{|the|toks@ #1\end }%
@@ -1347,7 +1344,7 @@
     |else |toks@|expandafter{|the|toks@ #1\end{#2}}%
     |fi|fi|fi
     |tabu@collectbody@forscan@next{}%
-}% \tabu@collectbody@forscan
+}% \tabu@collectbody@forscan@continue
 |long|def|tabu@pushbegins@forscan #1\begin#2{|ifx|relax#2|else b|expandafter|tabu@pushbegins@forscan|fi}%
 |catcode`|\ |z@
 \catcode`\| 12
@@ -1390,7 +1387,7 @@
 \def\tabu@shorttrial {\setbox\tabu@box \hbox\bgroup \tabu@seteverycr
     \ifx \tabu@savecounters\relax \else
                 \let\tabu@savecounters \relax \tabu@clckpt \fi
-    $\iftabuscantokens \tabu@rescan \else \expandafter\@secondoftwo \fi
+    $\iftabuscantokens \scantokens \else \expandafter\@secondoftwo \fi
        \expandafter{\expandafter \tabuthepreamble
                          \the\tabu@thebody
                          \csname tabu@adl@endtrial\endcsname
@@ -1399,7 +1396,7 @@
 \def\tabu@longtrial {\setbox\tabu@box \hbox\bgroup \tabu@seteverycr
     \ifx \tabu@savecounters\relax \else
                 \let\tabu@savecounters \relax \tabu@clckpt \fi
-    \iftabuscantokens \tabu@rescan \else \expandafter\@secondoftwo \fi
+    \iftabuscantokens \scantokens \else \expandafter\@secondoftwo \fi
        \expandafter{\expandafter \tabuthepreamble
                          \the\tabu@thebody
                          \tabuendlongtrial}\egroup      % got \tabu@box
@@ -1422,7 +1419,7 @@
     \else               \expandafter\@secondoftwo
     \fi
         {\expandafter \tabu@closetrialsgroup \expandafter
-         \tabu@rescan \expandafter{%
+         \scantokens \expandafter{%
                     \expandafter\tabuthepreamble
                         \the\expandafter\tabu@thebody
                                     \iftabu@long \else \endarray \fi}}

--- a/tabu.sty
+++ b/tabu.sty
@@ -1312,7 +1312,7 @@
 \catcode`\\ 12
 |long|def|tabu@collectbody@forscan #1#2#3\end{%
     |def|tabu@collectbody@forscan@next{|tabu@collectbody@forscan{#1}}%
-    |def|tabu@collectbody@forscan@partial{#2#3}%
+    |toks|tw@{#2#3}%
     |futurelet|tabu@temp@token|tabu@collectbody@forscan@a
 }% \tabu@collectbody@forscan
 |def|tabu@collectbody@forscan@a{%
@@ -1323,11 +1323,11 @@
     |fi
 }% \tabu@collectbody@forscan@a
 |def|tabu@collectbody@forscan@aa #1{%
-    |expandafter|tabu@collectbody@forscan@next|expandafter{|tabu@collectbody@forscan@partial\end#1}%
+    |expandafter|tabu@collectbody@forscan@next|expandafter{|the|toks|tw@\end#1}%
 }% \tabu@collectbody@forscan@aa
 |def|tabu@collectbody@forscan@b #1{%
     |edef|tabu@stack{|expandafter|tabu@pushbegins@forscan
-                     |tabu@collectbody@forscan@partial\begin|relax|expandafter|@gobble|tabu@stack}%
+                     |the|toks|tw@\begin|relax|expandafter|@gobble|tabu@stack}%
     |ifx |tabu@stack|@empty
         |expandafter|tabu@collectbody@forscan@end
     |else
@@ -1336,9 +1336,7 @@
     {#1}%
 }% \tabu@collectbody@forscan@b
 |def|tabu@collectbody@forscan@end #1{%
-    |edef|tabu@@temp{|tabu@thebody{|the|toks@
-                                   |unexpanded|expandafter{|tabu@collectbody@forscan@partial}}%
-                    }%
+    |edef|tabu@@temp{|tabu@thebody{|the|toks@|the|toks|tw@}}%
     |toks@|expandafter{|tabu@@temp
             |def|tabu@end@envir{|end{#1}}%
             |iftabu@long |def|tabu@endenvir {|end{#1}|tabu@gobbleX}%
@@ -1349,7 +1347,7 @@
     |tabu@collectbody@forscan@next
 }% \tabu@collectbody@forscan@end
 |def|tabu@collectbody@forscan@continue #1{%
-    |edef|tabu@@temp{|the|toks@|unexpanded|expandafter{|tabu@collectbody@forscan@partial\end}}%
+    |edef|tabu@@temp{|the|toks@|the|toks|tw@\end}%
     |def|tabu@temp{#1}%
     |ifx |tabu@temp|@empty |toks@|expandafter{|tabu@@temp}%
     |else |ifx|tabu@temp|tabu@@spxiii |toks@|expandafter{|tabu@@temp#1}%

--- a/testfiles/t003.lvt
+++ b/testfiles/t003.lvt
@@ -1,0 +1,26 @@
+\documentclass{article}
+\usepackage{fancyvrb}
+\usepackage{tabu}
+\newenvironment{yyyyyy}{START}{END}
+\input{regression-test}
+\begin{document}
+
+\START
+\begin{tabu*}to\linewidth{|XX|}
+% if }{ in the short verb then already not working in tabu 2.09
+A short verb: \verb|$&\~{}|&
+\begin{Verbatim}[commandchars={\\\{\}}]
+And \textit{this} is a \textbf{\textrm{complete}}
+Verbatim environment $&\~\textbraceleft\textbraceright 
+{\footnotesize this is smaller}
+\textit{spaces    are    ok    I    hope}
+\begin{yyyyyy}hello\end{yyyyyy} works
+(if on multiple lines it already
+does not work
+outside of a tabu cell, anyway)
+\normalfont\yyyyyy hello\endyyyyyy works too
+\end{Verbatim}
+\\
+\end{tabu*}
+
+\end{document}

--- a/testfiles/t003.lvt
+++ b/testfiles/t003.lvt
@@ -8,17 +8,31 @@
 \START
 \begin{tabu*}to\linewidth{|XX|}
 % if }{ in the short verb then already not working in tabu 2.09
-A short verb: \verb|$&\~{}|&
+A short verb: \verb|$&\~{}|&\\
 \begin{Verbatim}[commandchars={\\\{\}}]
 And \textit{this} is a \textbf{\textrm{complete}}
-Verbatim environment $&\~\textbraceleft\textbraceright 
+Verbatim environment $&~\textbraceleft\textbraceright 
 {\footnotesize this is smaller}
 \textit{spaces    are    ok    I    hope}
-\begin{yyyyyy}hello\end{yyyyyy} works
-(if on multiple lines it already
-does not work
-outside of a tabu cell, anyway)
-\normalfont\yyyyyy hello\endyyyyyy works too
+\normalfont\yyyyyy\begin{yyyyyy}hello\end{yyyyyy}hello\endyyyyyy
+\def\foo{foo}\meaning\foo
+\meaning\foo (ok as each line is\
+scoped by fancyvrb)
+\begin{Large}AA{\footnotesize{}BB}CC\end{Large}
+\begin{Large}AA\begin{footnotesize}BB\end{footnotesize}CC\end{Large}
+\end{Verbatim}
+&
+\begin{Verbatim}
+And \textit{this} is a \textbf{\textrm{complete}}
+Verbatim environment $&~\textbraceleft\textbraceright 
+{\footnotesize this is smaller}
+\textit{spaces    are    ok    I    hope}
+\normalfont\yyyyyy\begin{yyyyyy}hello\end{yyyyyy}hello\endyyyyyy
+\def\foo{foo}\meaning\foo
+\meaning\foo (ok as each line is\
+scoped by fancyvrb)
+\begin{Large}AA{\footnotesize{}BB}CC\end{Large}
+\begin{Large}AA\begin{footnotesize}BB\end{footnotesize}CC\end{Large}
 \end{Verbatim}
 \\
 \end{tabu*}

--- a/testfiles/t003.lvt
+++ b/testfiles/t003.lvt
@@ -8,7 +8,7 @@
 \START
 \begin{tabu*}to\linewidth{|XX|}
 % if }{ in the short verb then already not working in tabu 2.09
-A short verb: \verb|$&\~{}|&\\
+A short verb: \verb|$&\~{}#|&\\
 \begin{Verbatim}[commandchars={\\\{\}}]
 And \textit{this} is a \textbf{\textrm{complete}}
 Verbatim environment $&~\textbraceleft\textbraceright 
@@ -17,7 +17,7 @@ Verbatim environment $&~\textbraceleft\textbraceright
 \normalfont\yyyyyy\begin{yyyyyy}hello\end{yyyyyy}hello\endyyyyyy
 \def\foo{foo}\meaning\foo
 \meaning\foo (ok as each line is\
-scoped by fancyvrb)
+scoped by fancyvrb) #
 \begin{Large}AA{\footnotesize{}BB}CC\end{Large}
 \begin{Large}AA\begin{footnotesize}BB\end{footnotesize}CC\end{Large}
 \end{Verbatim}
@@ -30,7 +30,7 @@ Verbatim environment $&~\textbraceleft\textbraceright
 \normalfont\yyyyyy\begin{yyyyyy}hello\end{yyyyyy}hello\endyyyyyy
 \def\foo{foo}\meaning\foo
 \meaning\foo (ok as each line is\
-scoped by fancyvrb)
+scoped by fancyvrb) #
 \begin{Large}AA{\footnotesize{}BB}CC\end{Large}
 \begin{Large}AA\begin{footnotesize}BB\end{footnotesize}CC\end{Large}
 \end{Verbatim}


### PR DESCRIPTION
I have not looked entirety of codebase, I made this patch until I could my test file compile without error. I have not checked if it breaks something else.

In particular, I wish I could build the documentation but I see that previous patches were done only on sty file, so after having worked on dtx I had to cherry-pick to modify only the sty file.

Again, this is a bit WIP, it works on test file. Not tested on anything serious (I am not tabu user to start with... so I have nil experience).

The method implements the "catcode 12" idea. Difficulty is when input contains `\endfoo` for example. Besides I tested that multi-line environments

```latex
\begin{foo}
 aaa
\end{foo}
```

do not work in Verbatim already outside of tabu, (**edit** of course, as each input line is scoped by fancyvrb) so I did not worry about this. But `\begin{foo}aaa\end{foo}` is now allowed in the alltt-type Verbatim inside tabu cell.

While working on this I got the fleeting feeling original code could cause some brace removal, I did not stop to ponder too much. (and I do not understand fully all branches of original (the thing with `#3` empty at one location); I took out some conditional material because that is now the matter of my added code, but in what is left there might now some unneeded thing now for same reason).

Again, once trivial bugs in my draft were fixed, I decided to post this without not much testing as I have no test files to start with apart the one I am contributing.


Fixes: #3 
